### PR TITLE
Small syntax fix for rename attribute

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
@@ -106,7 +106,7 @@ public class UMLClass {
         }
     
         // If control reaches this point, the old attribute does not exist for this class
-        System.out.print("Attribute \"" + oldName + "\" is not an attribute of class\"" + name + "\""
+        System.out.print("Attribute \"" + oldName + "\" is not an attribute of class\"" + name + "\"");
         return false;
     }
 }


### PR DESCRIPTION
Added a closing paren and semicolon that were mysteriously missing