### PR TITLE
Save functionality added to the class and editor files

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
@@ -2,6 +2,10 @@ package org.jinxs.umleditor;
 
 import java.util.ArrayList;
 
+// For building a JSON object for the class
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
 public class UMLClass {
     // Name of this class
     public String name;
@@ -108,5 +112,44 @@ public class UMLClass {
         // If control reaches this point, the old attribute does not exist for this class
         System.out.print("Attribute \"" + oldName + "\" is not an attribute of class\"" + name + "\"");
         return false;
+    }
+
+    // Saves the contents of the class into a JSONObject
+    // The name of the class is a single pair while the relationships
+    // and attributes are saved as arrays. Due to the structure of the relationships,
+    // each individual relationship is saved as an object of two pairs
+    public JSONObject saveClass() {
+        // Create the class object and add the name of the class
+        JSONObject classJObject = new JSONObject();
+        classJObject.put("name", name);
+
+        // Add all relationships for the class into a JSON array
+        JSONArray relsJArray = new JSONArray();
+        for (int i = 0; i < relationships.size(); ++i) {
+            // Put each relationship into its own object containing two pairs:
+            // 1: the name of the other class in the relationship named "className"
+            // 2: the status of the relationship, either "src" or "dest" name "src/dest"
+            JSONObject relJObject = new JSONObject();
+            relJObject.put("className", relationships.get(i).get(0));
+            relJObject.put("src/dest", relationships.get(i).get(1));
+            
+            // Add each relationship object to the relationship array
+            relsJArray.add(relJObject);
+        }
+
+        // Add the rel array to the class object
+        classJObject.put("relationships", relsJArray);
+
+        // Add all attributes for the class into a JSON array
+        JSONArray attrsJArray = new JSONArray();
+        for (int i = 0; i < attributes.size(); ++i) {
+            attrsJArray.add(attributes.get(i));
+        }
+        
+        // Add the array of attributes to the class object
+        classJObject.put("attributes", attrsJArray);
+
+        // Everything is added, so the class object is finished
+        return classJObject;
     }
 }

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
@@ -2,6 +2,13 @@ package org.jinxs.umleditor;
 
 import java.util.ArrayList;
 
+// For writing out to a file when saving
+import java.io.FileWriter;
+import java.io.IOException;
+
+// For the JSON array of classes to be written to file
+import org.json.simple.JSONArray;
+
 public class UMLEditor {
     
     private ArrayList<UMLClass> classes;
@@ -312,6 +319,26 @@ public class UMLEditor {
         // Prints out the name of each class
         for (int i = 0; i < classes.size(); ++i) {
             System.out.println(classes.get(i).name);
+        }
+    }
+
+    public void save(String fileName) {
+        // Create a JSON array to hold all of the classes
+        JSONArray classJArray = new JSONArray();
+
+        // Loop through the list of classes to save each class and add its
+        // resulting JSON object to the JSON class array
+        for (int i = 0; i < classes.size(); ++i) {
+            classJArray.add(classes.get(i).saveClass());
+        }
+
+        // Write out the JSON class array to the desired filename and catch
+        // IOExceptions if they occur (which will result in a stack trace)
+        try (FileWriter file = new FileWriter(fileName + ".json")) {
+            file.write(classJArray.toJSONString());
+            file.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
Save functionality added and already works with the interface file. Testing this functionality results in a file of the same format as the produced format file in "resources" on Discord. NOTE: the order of the items in each class object, or any JSON object for that matter, DOES NOT MATTER. Personal testing resulted in the name of the class being listed after the array of relationships, but each item in an object is obtained by using the key of each item in that object (JSON objects operate like maps; it doesn't rely on indexing). In short, JSON has full control over the order that items appear, and this fundamentally should not alter any attempts to read the file, no matter the order