### PR TITLE
Added line to create a new "saves" directory once "save" is called

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
@@ -355,6 +355,8 @@ public class UMLEditor {
         // Write out the JSON class array to the desired filename and put it in the "saves" directory
         // and catch IOExceptions if they occur (which will result in a stack trace)
         String filePath = new File("").getAbsolutePath();
+        // Make a "saves" directory in the umleditor to hold JSON save files
+        new File(filePath + "/UMLEditor/src/main/java/org/jinxs/umleditor/saves").mkdirs();
         try (FileWriter file = new FileWriter(filePath + "/UMLEditor/src/main/java/org/jinxs/umleditor/saves/" + fileName + ".json")) {
             file.write(classJArray.toJSONString());
             file.flush();


### PR DESCRIPTION
GitHub apparently does not allow the addition of an empty directory to a repo, so the saves directory must be made by the code. When the user calls "save" in the editor, the "saves" directory is created, and all JSON save files will be put into that directory