### PR TITLE
Removed the duplicate getClasses method from UMLEditor

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
@@ -500,11 +500,6 @@ public class UMLEditor {
         }
     }
 
-    public ArrayList<UMLClass> getClasses(){
-
-        return classes; 
-    }
-
     public void save(String fileName) {
         // Create a JSON array to hold all of the classes
         JSONArray classJArray = new JSONArray();


### PR DESCRIPTION
We had a duplicate of the getClasses method, so I removed it.