### PR TITLE
Fixed deleteAllParams to delete properly

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLClass.java
@@ -251,11 +251,9 @@ public class UMLClass {
             return false;
         }
 
-        for (int i = 1; i < targetMethod.size(); ++i){
-            targetMethod.remove(i);
+        while (targetMethod.size() > 1) {
+            targetMethod.remove(1);
         }
-
-        targetMethod.remove(targetMethod.size() -1);
 
         return true;
     }


### PR DESCRIPTION
Using the size of the method ArrayList in a loop that removes from that ArrayList causes a index-out-of-bounds issue because the size is changing every time "remove" is called, so I changed it to remove the first parameter while the size is > 0, because "remove" also shifts every other element in the ArrayList to left by one