### PR TITLE
Fixed bug if user does not specify a number when prompting for params

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLGUI.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLGUI.java
@@ -463,8 +463,22 @@ public class UMLGUI implements ActionListener{
         if (command.equals("Rename All Parameters")){
             String className = getText("Class: "); 
             String methodName = getText("Name of method to change all params: "); 
-            String numOfParams = getText("How many params to add: ");
-            int paramNum = Integer.parseInt(numOfParams);
+
+            // parseInt will fail if given a non-number, so the user
+            // will be continuously asked for a number of parameters
+            // until they provide a number
+            boolean inputIsInt = false;
+            int paramNum = 0;
+            while (!inputIsInt) {
+                String numOfParams = getText("How many params to add: ");
+                try {
+                    inputIsInt = true;
+                    paramNum = Integer.parseInt(numOfParams);
+                } catch (Exception numberFormatException) {
+                    inputIsInt = false;
+                }
+            }
+
             ArrayList<String> params = new ArrayList<String>(paramNum);
             while (paramNum > 0){
                 String paramName = getText("New param name: ");


### PR DESCRIPTION
As the title says. If the user gave a string of characters instead of a number, the GUI would crash. Now it doesn't and will keep asking until the user specifies a number