### PR TITLE
Fixed weird rel loading bug and extraneous attempt to load rels

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLEditor.java
@@ -603,10 +603,8 @@ public class UMLEditor {
 
                     // Add the relationship in the correct order based on whether the
                     // current class is the source or destination
-                    if (relStatus.equals("src")){
+                    if (relStatus.equals("dest")){
                         this.addRel(className, (String) relation.get("className"), relType);
-                    } else { // status == dest
-                        this.addRel((String) relation.get("className"), className, relType);
                     }
                 }
 


### PR DESCRIPTION
Relationship loading was somehow loading in the wrong src/dest order, so that's fixed now. Also, relationships are only added once, so the extraneous "Relationship between "class" and "class" already exists" does not print when loading.