### PR TITLE
Fix bugs that caused arrow caps to not appear at certain points

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLGUI.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLGUI.java
@@ -176,11 +176,15 @@ public class UMLGUI implements ActionListener{
                                     }
                                 }
 
-                                if (shouldDrawCap && !isInverse())
+                                g2d.setStroke(SOLID_STROKE);
+                                drawCap(g2d, isDiamond, type);
+                                /*
+                                if (shouldDrawCap)
                                 {
                                     g2d.setStroke(SOLID_STROKE);
                                     drawCap(g2d, isDiamond, type);
                                 }
+                                */
                         }
         
                     } 


### PR DESCRIPTION
This bug fix corrects and error that was preventing arrows from being drawn when the source and destination class objects were near eye level and when the destination class object was above the source class object.