### PR TITLE
Added Command design pattern to the CLI

### DIFF
--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/AddCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/AddCommand.java
@@ -1,0 +1,98 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class AddCommand extends CLICommand{
+    
+    public AddCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if (UMLObject.equals("class")) {
+            if (args.size() < 2) {
+                System.out.println("Too few Arguments for addClass command");
+                return false;
+            }
+            else if (args.size() > 2) {
+                System.out.println("Too many Arguments for addClass command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                if (!project.addClass(args.get(1))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("rel")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for addRel command");
+                return false;
+            }
+            else if (args.size() > 4) {
+                System.out.println("Too many Arguments for addRel command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                project.addRel(args.get(1), args.get(2), args.get(3));
+                return true;
+            }
+        } else if (UMLObject.equals("field")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for addfield command");
+                return false;
+            }
+            else if (args.size() > 4) {
+                System.out.println("Too many Arguments for addfield command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                if (!project.addAttr(args.get(1), args.get(3), args.get(0), args.get(2))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("method")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for addMethod command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                if (!project.addAttr(args.get(1), args.get(3),args.get(0), args.get(2))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                else {
+                    for(int i = 4; i < args.size(); i += 2){
+                        project.addParam(args.get(1), args.get(3), args.get(i + 1), args.get(i));
+                    }
+                    return true;
+                }
+            }
+        } else if (UMLObject.equals("param")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for addParam command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                for(int i = 3; i < args.size(); i += 2){
+                    project.addParam(args.get(1), args.get(2), args.get(i + 1), args.get(i)); 
+                }
+                return true;
+            }
+        } else {
+            System.out.println("Add + " + args.get(0) + " is not a valid command");
+            return false;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/CLICommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/CLICommand.java
@@ -1,0 +1,22 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+// Abstract base command that each CLI command instance will implement
+public abstract class CLICommand {
+    public UMLEditor project;
+    public String UMLObject;
+    public ArrayList<String> args;
+
+    CLICommand(UMLEditor editor, String object, ArrayList<String> commands) {
+        this.project = editor;
+        this.UMLObject = object;
+        this.args = commands;
+    }
+    
+    // Each command will override to perform its respective command from the controller
+    // Returns true if the command changes the project state, false if not
+    public abstract boolean execute();
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/CopyCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/CopyCommand.java
@@ -1,0 +1,30 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class CopyCommand extends CLICommand{
+    
+    public CopyCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if (args.size() < 2) {
+            System.out.println("Too few Arguments for copy command");
+            return false;
+        } else if (args.size() > 2) {
+            System.out.println("Too many Arguments for copy command");
+            return false;
+        } else {
+            project.saveToMeme(true);
+            if (!project.copyClass(args.get(0), args.get(1))) {
+                project.removeLastSave();
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/DeleteCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/DeleteCommand.java
@@ -1,0 +1,86 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class DeleteCommand extends CLICommand{
+    
+    public DeleteCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if (UMLObject.equals("class")) {
+            if (args.size() < 2) {
+                System.out.println("Too few Arguments for deleteClass command");
+                return false;
+            }
+            else if (args.size() > 2) {
+                System.out.println("Too many Arguments for deleteClass command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                project.deleteClass(args.get(1));
+                return true;
+            }
+        } else if (UMLObject.equals("rel")) {
+            if (args.size() < 3) {
+                System.out.println("Too few Arguments for deleteRel command");
+                return false;
+            }
+            else if (args.size() > 3) {
+                System.out.println("Too many Arguments for deleteRel command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                project.delRel(args.get(1), args.get(2));
+                return true;
+            }
+        } else if (UMLObject.equals("field")) {
+            if (args.size() < 3) {
+                System.out.println("Too few Arguments for deletefield command");
+                return false;
+            }
+            else if (args.size() > 3) {
+                System.out.println("Too many Arguments for deletefield command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                project.delAttr(args.get(1), args.get(2), args.get(0));
+                return true;
+            }
+        } else if (UMLObject.equals("method")) {
+            if (args.size() < 3) {
+                System.out.println("Too few Arguments for deleteMethod command");
+                return false;
+            }
+            project.saveToMeme(true);
+            project.delAttr(args.get(1), args.get(2),args.get(0));
+            return true;
+        } else if (UMLObject.equals("param")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for addParam command");
+                return false;
+            }
+            project.saveToMeme(true);
+            project.deleteParam(args.get(1), args.get(2), args.get(3));
+            return true;
+        } else if (UMLObject.equals("allParams")) {
+            if (args.size() < 3) {
+                System.out.println("Too few Arguments for deleteAllParams command");
+                return false;
+            }
+            project.saveToMeme(true);
+            project.deleteAllParams(args.get(1), args.get(2));
+            return true;
+        } else {
+            System.out.println("Delete + " + args.get(0) + " is not a valid command");
+            return false;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/PrintContentsCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/PrintContentsCommand.java
@@ -1,0 +1,28 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class PrintContentsCommand extends CLICommand{
+    
+    public PrintContentsCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if(args.size() < 1){
+            System.out.println("Too few Arguments for printClassContents command");
+            return false;
+        }
+        else if(args.size() > 1){
+            System.out.println("Too many Arguments for printClassContents command");
+            return false;
+        }
+        else{
+            project.printClassContents(args.get(0)); 
+            return true;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/PrintRelCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/PrintRelCommand.java
@@ -1,0 +1,28 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class PrintRelCommand extends CLICommand{
+    
+    public PrintRelCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if(args.size() < 1){
+            System.out.println("Too few Arguments for printRel command");
+            return false;
+        }
+        else if(args.size() > 1){
+            System.out.println("Too many Arguments for printRel command");
+            return false;
+        }
+        else{
+            project.printRel(args.get(0)); 
+            return true;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/RenameCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/RenameCommand.java
@@ -1,0 +1,97 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class RenameCommand extends CLICommand{
+    
+    public RenameCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if (UMLObject.equals("class")) {
+            if (args.size() < 3) {
+                System.out.println("Too few Arguments for renameClass command");
+                return false;
+            }
+            else if (args.size() > 3) {
+                System.out.println("Too many Arguments for renameClass command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                if (!project.renameClass(args.get(1),args.get(2))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("field")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for renamefield command");
+                return false;
+            }
+            else if (args.size() > 4) {
+                System.out.println("Too many Arguments for renamefield command");
+                return false;
+            }
+            else{
+                project.saveToMeme(true);
+                if (!project.renameAttr(args.get(1), args.get(2), args.get(3), args.get(0))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("method")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for renameMethod command");
+                return false;
+            }
+            else if (args.size() > 4) {
+                System.out.println("Too many Arguments for renameMethod command");
+                return false;
+            }
+            project.saveToMeme(true);
+            if (!project.renameAttr(args.get(1), args.get(2),args.get(3),args.get(0))) {
+                project.removeLastSave();
+                return false;
+            }
+            return true;
+        } else if (UMLObject.equals("param")) {
+            if (args.size() < 5) {
+                System.out.println("Too few Arguments for renameParam command");
+                return false;
+            }
+            project.saveToMeme(true);
+            if (!project.changeParamName(args.get(1), args.get(2), args.get(3), args.get(4))) {
+                project.removeLastSave();
+                return false;
+            }
+            return true;
+        } else if (UMLObject.equals("allParams")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for renameAllParams command");
+                return false;
+            }
+            ArrayList<String> params = new ArrayList<String>();
+            ArrayList<String> pTypes = new ArrayList<String>();
+            for(int i = 3; i < args.size(); i += 2){
+                params.add(args.get(i + 1));
+                pTypes.add(args.get(i));
+            }
+            project.saveToMeme(true);
+            if (!project.changeAllParams(args.get(1), args.get(2), params, pTypes)) {
+                project.removeLastSave();
+                return false;
+            }
+            return true;
+        } else {
+            System.out.println("Rename + " + args.get(0) + " is not a valid command");
+            return false;
+        }
+    }
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/Command/RetypeCommand.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/Command/RetypeCommand.java
@@ -1,0 +1,77 @@
+package org.jinxs.umleditor.Command;
+
+import java.util.ArrayList;
+
+import org.jinxs.umleditor.UMLEditor;
+
+public class RetypeCommand extends CLICommand{
+    
+    public RetypeCommand(UMLEditor editor, String object, ArrayList<String> args) {
+        super(editor, object, args);
+    }
+
+    @Override
+    public boolean execute() {
+        if (UMLObject.equals("rel")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for change relType command");
+                return false;
+            } else if (args.size() > 4) {
+                System.out.println("Too many Arguments for change relType command");
+                return false;
+            } else {
+                project.saveToMeme(true);
+                project.changeRelType(args.get(1), args.get(2), args.get(3));
+                return true;
+            }
+        } else if (UMLObject.equals("field")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for change fieldType command");
+                return false;
+            } else if (args.size() > 4) {
+                System.out.println("Too many Arguments for change fieldType command");
+                return false;
+            } else {
+                project.saveToMeme(true);
+                if (!project.changeFieldType(args.get(1), args.get(2), args.get(3))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("method")) {
+            if (args.size() < 4) {
+                System.out.println("Too few Arguments for change methodType command");
+                return false;
+            } else if (args.size() > 4) {
+                System.out.println("Too many Arguments for change methodType command");
+                return false;
+            } else {
+                project.saveToMeme(true);
+                if (!project.changeMethodType(args.get(1), args.get(2), args.get(3))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else if (UMLObject.equals("param")) {
+            if (args.size() < 5) {
+                System.out.println("Too few Arguments for change paramType command");
+                return false;
+            } else if (args.size() > 5) {
+                System.out.println("Too many Arguments for change paramType command");
+                return false;
+            } else {
+                project.saveToMeme(true);
+                if (!project.changeParamType(args.get(1), args.get(2), args.get(3), args.get(4))) {
+                    project.removeLastSave();
+                    return false;
+                }
+                return true;
+            }
+        } else {
+            System.out.println("Retype + " + args.get(0) + " is not a valid command");
+            return false;
+        }
+    } 
+}

--- a/UMLEditor/src/main/java/org/jinxs/umleditor/UMLTerminal.java
+++ b/UMLEditor/src/main/java/org/jinxs/umleditor/UMLTerminal.java
@@ -13,7 +13,13 @@ import java.nio.file.Paths;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-
+import org.jinxs.umleditor.Command.AddCommand;
+import org.jinxs.umleditor.Command.CopyCommand;
+import org.jinxs.umleditor.Command.DeleteCommand;
+import org.jinxs.umleditor.Command.PrintContentsCommand;
+import org.jinxs.umleditor.Command.PrintRelCommand;
+import org.jinxs.umleditor.Command.RenameCommand;
+import org.jinxs.umleditor.Command.RetypeCommand;
 import org.jline.reader.*;
 import org.jline.reader.impl.completer.AggregateCompleter;
 import org.jline.terminal.*;
@@ -94,7 +100,7 @@ public class UMLTerminal{
             //Exits the program
             case "quit":
                 try{
-                terminal.close();
+                    terminal.close();
                 }
                 catch(IOException e){
                     System.out.println("Terminal failed to close");
@@ -111,292 +117,35 @@ public class UMLTerminal{
                 }
             break;
 
-            //Add a class to the project
+            //Add an object to the project
             case "add":
-                switch(commands.get(1)){
-                    case "class":
-                        if (commands.size() < 3) {
-                            System.out.println("Too few Arguments for addClass command");
-                        }
-                        else if (commands.size() > 3) {
-                            System.out.println("Too many Arguments for addClass command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            if (!project.addClass(commands.get(2))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "rel":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for addRel command");
-                        }
-                        else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for addRel command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            project.addRel(commands.get(2), commands.get(3), commands.get(4));
-                        }
-                    break; 
-
-                    case "field":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for addfield command");
-                        }
-                        else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for addfield command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            if (!project.addAttr(commands.get(2), commands.get(4), commands.get(1), commands.get(3))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "method":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for addMethod command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            if (!project.addAttr(commands.get(2), commands.get(4),commands.get(1), commands.get(3))) {
-                                project.removeLastSave();
-                            }
-                            else {
-                                for(int i = 5; i < commands.size(); i += 2){
-                                    project.addParam(commands.get(2), commands.get(4), commands.get(i + 1), commands.get(i));
-                                }
-                            }
-                        }
-                    break; 
-                    
-                    case "param":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for addParam command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            for(int i = 4; i < commands.size(); i += 2){
-                                project.addParam(commands.get(2), commands.get(3), commands.get(i + 1), commands.get(i)); 
-                            }
-                        }
-                    break; 
-
-                    default:
-                        System.out.println("Add + " + commands.get(1) + " is not a valid command"); 
-                    break;
-
-                }
+                commands.remove(0);
+                AddCommand add = new AddCommand(project, commands.get(0), commands);
+                add.execute();
             break;
 
-            //Deletes a class from the project
+            //Deletes an object from the project
             case "delete":
-                switch(commands.get(1)){
-                    case "class":
-                        if (commands.size() < 3) {
-                            System.out.println("Too few Arguments for deleteClass command");
-                        }
-                        else if (commands.size() > 3) {
-                            System.out.println("Too many Arguments for deleteClass command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            project.deleteClass(commands.get(2));
-                        }
-                    break;
-
-                    case "rel":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for deleteRel command");
-                        }
-                        else if (commands.size() > 4) {
-                            System.out.println("Too many Arguments for deleteRel command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            project.delRel(commands.get(2), commands.get(3));
-                        }
-                    break; 
-
-                    case "field":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for deletefield command");
-                        }
-                        else if (commands.size() > 4) {
-                            System.out.println("Too many Arguments for deletefield command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            project.delAttr(commands.get(2), commands.get(3),commands.get(1));
-                        }
-                    break;
-
-                    case "method":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for deleteMethod command");
-                        }
-                        project.saveToMeme(true);
-                        project.delAttr(commands.get(2), commands.get(3),commands.get(1));
-                    break; 
-                    
-                    case "param":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for addParam command");
-                        }
-                        project.saveToMeme(true);
-                        project.deleteParam(commands.get(2), commands.get(3), commands.get(4));
-                    break; 
-
-                    case "allParams":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for deleteAllParams command");
-                        }
-                        project.saveToMeme(true);
-                        project.deleteAllParams(commands.get(2), commands.get(3));
-                    break; 
-
-                    default:
-                        System.out.println("Delete + " + commands.get(1) + " is not a valid command"); 
-                    break;
-
-                }
+                commands.remove(0);
+                DeleteCommand delete = new DeleteCommand(project, commands.get(0), commands);
+                delete.execute();
             break;
 
-            //Renames a class in the project to a new name
+            //Renames an object in the project to a new name
             case "rename":
-                switch(commands.get(1)){
-                    case "class":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for renameClass command");
-                        }
-                        else if (commands.size() > 4) {
-                            System.out.println("Too many Arguments for renameClass command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            if (!project.renameClass(commands.get(2),commands.get(3))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "field":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for renamefield command");
-                        }
-                        else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for renamefield command");
-                        }
-                        else{
-                            project.saveToMeme(true);
-                            if (!project.renameAttr(commands.get(2), commands.get(3), commands.get(4), commands.get(1))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "method":
-                        if (commands.size() < 4) {
-                            System.out.println("Too few Arguments for renameMethod command");
-                        }
-                        else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for renameMethod command");
-                        }
-                        project.saveToMeme(true);
-                        if (!project.renameAttr(commands.get(2), commands.get(3),commands.get(4),commands.get(1))) {
-                            project.removeLastSave();
-                        }
-                    break; 
-                    
-                    case "param":
-                        if (commands.size() < 6) {
-                            System.out.println("Too few Arguments for renameParam command");
-                        }
-                        project.saveToMeme(true);
-                        if (!project.changeParamName(commands.get(2), commands.get(3), commands.get(4), commands.get(5))) {
-                            project.removeLastSave();
-                        }
-                    break; 
-
-                    case "allParams":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for renameAllParams command");
-                        }
-                        ArrayList<String> params = new ArrayList<String>();
-                        ArrayList<String> pTypes = new ArrayList<String>();
-                        for(int i = 4; i < commands.size(); i += 2){
-                            params.add(commands.get(i + 1));
-                            pTypes.add(commands.get(i));
-                        }
-                        project.saveToMeme(true);
-                        if (!project.changeAllParams(commands.get(2), commands.get(3), params, pTypes)) {
-                            project.removeLastSave();
-                        }
-                    break; 
-
-                    default:
-                        System.out.println("Rename + " + commands.get(1) + " is not a valid command"); 
-                    break;
-                }
+                commands.remove(0);
+                RenameCommand rename = new RenameCommand(project, commands.get(0), commands);
+                rename.execute();
             break;
+
+            //Changes an object's type in the project
             case "retype":
-                switch(commands.get(1)) {
-                    case "rel":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for change relType command");
-                        } else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for change relType command");
-                        } else {
-                            project.saveToMeme(true);
-                            project.changeRelType(commands.get(2), commands.get(3), commands.get(4));
-                        }
-                    break;
-
-                    case "field":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for change fieldType command");
-                        } else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for change fieldType command");
-                        } else {
-                            project.saveToMeme(true);
-                            if (!project.changeFieldType(commands.get(2), commands.get(3), commands.get(4))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "method":
-                        if (commands.size() < 5) {
-                            System.out.println("Too few Arguments for change fieldType command");
-                        } else if (commands.size() > 5) {
-                            System.out.println("Too many Arguments for change fieldType command");
-                        } else {
-                            project.saveToMeme(true);
-                            if (!project.changeMethodType(commands.get(2), commands.get(3), commands.get(4))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-
-                    case "param":
-                        if (commands.size() < 6) {
-                            System.out.println("Too few Arguments for change fieldType command");
-                        } else if (commands.size() > 6) {
-                            System.out.println("Too many Arguments for change fieldType command");
-                        } else {
-                            project.saveToMeme(true);
-                            if (!project.changeParamType(commands.get(2), commands.get(3), commands.get(4), commands.get(5))) {
-                                project.removeLastSave();
-                            }
-                        }
-                    break;
-                }
+                commands.remove(0);
+                RetypeCommand retype = new RetypeCommand(project, commands.get(0), commands);
+                retype.execute();
             break;
-                //Saves current project into a JSON named file
+
+            //Saves current project into a JSON named file
             case "save":
                 if(commands.size() < 2){
                     System.out.println("Too few Arguments for save command");
@@ -437,28 +186,16 @@ public class UMLTerminal{
 
             //Prints the contents of a given class (i.e Relationships and attributes)
             case "printContents":
-                if(commands.size() < 2){
-                    System.out.println("Too few Arguments for printClassContents command");
-                }
-                else if(commands.size() > 2){
-                    System.out.println("Too many Arguments for printClassContents command");
-                }
-                else{
-                    project.printClassContents(commands.get(1)); 
-                }
+                commands.remove(0);
+                PrintContentsCommand printContents = new PrintContentsCommand(project, commands.get(0), commands);
+                printContents.execute();
             break;
 
             //Prints the relationships of a given classes and labels the src and destination class
             case "printRel":
-                if(commands.size() < 2){
-                    System.out.println("Too few Arguments for printRel command");
-                }
-                else if(commands.size() > 2){
-                    System.out.println("Too many Arguments for printRel command");
-                }
-                else{
-                    project.printRel(commands.get(1)); 
-                }
+                commands.remove(0);
+                PrintRelCommand printRel = new PrintRelCommand(project, commands.get(0), commands);
+                printRel.execute();
             break;
 
             case "undo":
@@ -482,16 +219,9 @@ public class UMLTerminal{
             break;
 
             case "copy":
-                if (commands.size() < 3) {
-                    System.out.println("Too few Arguments for copy command");
-                } else if (commands.size() > 3) {
-                    System.out.println("Too many Arguments for copy command");
-                } else {
-                    project.saveToMeme(true);
-                    if (!project.copyClass(commands.get(1), commands.get(2))) {
-                        project.removeLastSave();
-                    }
-                }
+                commands.remove(0);
+                CopyCommand copy = new CopyCommand(project, commands.get(0), commands);
+                copy.execute();
             break;
 
             //If command is not one of the specified commands above then we print an error message


### PR DESCRIPTION
Added a CLICommand base class that each CLI command implements. I only changed commands that do not use functions in the Terminal file and/or commands that are so short that they may result in an out-of-bounds exception if the user types the command wrong.